### PR TITLE
Build and publish wheels on GitHub Actions using maturin-action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,165 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: x64
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+      - name: Build wheels - x86_64
+        uses: messense/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist
+      - name: Install built wheel - x86_64
+        run: |
+          pip install numpy
+          pip install panther --no-deps --no-index --find-links dist --force-reinstall
+          python -c 'import panther'
+      - name: Build wheels - universal2
+        uses: messense/maturin-action@v1
+        with:
+          args: --release --universal2 --out dist --no-sdist
+      - name: Install built wheel - universal2
+        run: |
+          pip install panther --no-deps --no-index --find-links dist --force-reinstall
+          python -c 'import panther'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [x64, x86]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --no-sdist
+      - name: Install built wheel
+        run: |
+          pip install numpy
+          pip install panther --no-deps --no-index --find-links dist --force-reinstall
+          python -c 'import panther'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64, i686]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+        architecture: x64
+    - name: Build wheels
+      uses: messense/maturin-action@v1
+      with:
+        rust-toolchain: nightly
+        target: ${{ matrix.target }}
+        manylinux: auto
+        args: --release --out dist --no-sdist
+    - name: Install built wheel
+      if: matrix.target == 'x86_64'
+      run: |
+        pip install numpy
+        pip install panther --no-deps --no-index --find-links dist --force-reinstall
+        python -c 'import panther'
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: dist
+
+  linux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [aarch64, armv7, s390x, ppc64le]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Build wheels
+      uses: messense/maturin-action@v1
+      with:
+        rust-toolchain: nightly
+        target: ${{ matrix.target }}
+        manylinux: auto
+        args: --release --out dist --no-sdist
+    - uses: uraimo/run-on-arch-action@v2.0.5
+      name: Install built wheel
+      if: matrix.target == 'aarch64'
+      with:
+        arch: ${{ matrix.target }}
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        install: |
+          apt-get update
+          apt-get install -y --no-install-recommends python3 python3-pip
+          pip3 install -U pip numpy
+        run: |
+          pip3 install panther --no-deps --no-index --find-links dist/ --force-reinstall
+          python3 -c 'import panther'
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [ macos, windows, linux, linux-cross ]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - name: Publish to PyPi
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        uses: messense/maturin-action@v1
+        with:
+          command: upload
+          args: --skip-existing *

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock
 
 /target
 #Cargo.lock
+
+# Add for maturin
+dist/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ name = "panther"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.12.3", features = ["extension-module"] }
+pyo3 = { version = "0.15.1", features = ["abi3-py36", "extension-module"] }
 numpy = "0.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["maturin>=0.12,<0.13"]
+build-backend = "maturin"
+
+[project]
+name = "panther"
+dependencies = [
+    "numpy"
+]


### PR DESCRIPTION
Unfortunately the `panther` package name is already taken on PyPI: https://pypi.org/project/panther/ , so you need to rename the Python package.

Fixes #3 